### PR TITLE
fix: use focusableElementsString instead of 'button' selector

### DIFF
--- a/px-modal.html
+++ b/px-modal.html
@@ -344,10 +344,7 @@ Custom property | Description
        */
       _getFocusableElements() {
         const focusableElementsString = 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex="0"], [contenteditable]';
-        let focusableSlottedElements = Polymer.dom(this).querySelectorAll('button') || [];
-        if (focusableSlottedElements instanceof NodeList) {
-          focusableSlottedElements = Array.prototype.slice.call(focusableSlottedElements);
-        }
+        const focusableSlottedElements = Array.prototype.slice.call(Polymer.dom(this).querySelectorAll(focusableElementsString));
         const shadowAcceptTrigger = Polymer.dom(this.root).querySelector('#accept-trigger-button');
         const shadowRejectTrigger = Polymer.dom(this.root).querySelector('#reject-trigger-button');
         const slottedAcceptTrigger = focusableSlottedElements.find(n => n.getAttribute('slot') === 'accept-trigger');

--- a/test/px-modal-fixture.html
+++ b/test/px-modal-fixture.html
@@ -61,5 +61,34 @@
         </div>
       </template>
     </test-fixture>
+
+    <test-fixture id="ModalFixtureWithFocusableElements">
+      <template>
+        <div>
+          <px-modal>
+            <h1 slot="header">Different kinds of focusable elements</h1>
+            <div slot="body">
+              <a href="https://example.com">Anchor with href</a>
+              <a>Anchor without href, shoudn't be focusable</a>
+              <div tabindex="0">focusable div</div>
+              <input type="text">
+              <input type="text" disabled>
+              <select>
+                <option></option>
+              </select>
+              <select disabled>
+                <option></option>
+              </select>
+              <div contenteditable>div contenteditable</div>
+            </div>
+            <button slot="reject-trigger" id="rejectButton">Cancel</button>
+            <button slot="accept-trigger" id="acceptButton">Permanently Delete Record</button>
+          </px-modal>
+          <px-modal-trigger>
+            <button id="openButton">Open Modal</button>
+          </px-modal-trigger>
+        </div>
+      </template>
+    </test-fixture>
   </body>
 </html>

--- a/test/px-modal-tests.js
+++ b/test/px-modal-tests.js
@@ -162,3 +162,29 @@ describe('px-modal [slots]', () => {
     expect(eventCallback).to.be.calledOnce;
   });
 });
+
+describe('px-modal with different focusable elements', () => {
+  let fx;
+  let modal;
+  let trigger;
+  let openButton;
+
+  beforeEach((done) => {
+    fx = fixture('ModalFixtureWithFocusableElements');
+    modal = fx.querySelector('px-modal');
+    trigger = fx.querySelector('px-modal-trigger');
+    openButton = fx.querySelector('#openButton');
+    flush(() => {
+      /* Bind the trigger to the modal */
+      modal.openTrigger = trigger.trigger;
+      done();
+    });
+  });
+
+  it('should return the correct array of focusable elements', () => {
+    openButton.click();
+    const focusableElements = modal._getFocusableElements();
+    expect(focusableElements.length).to.equal(7);
+  });
+
+});


### PR DESCRIPTION
`focusableElementsString` was defined but never used: https://github.com/predixdesignsystem/px-modal/search?utf8=%E2%9C%93&q=focusableElementsString&type=

This PR will use it instead of hardcoded `'button'` selector.