### PR TITLE
Improve looking up for focusable elements inside the modal

### DIFF
--- a/px-modal.html
+++ b/px-modal.html
@@ -2,6 +2,7 @@
 <link rel="import" href="px-modal-trigger.html"/>
 <link rel="import" href="css/px-modal-styles.html"/>
 <link rel="import" href="../iron-fit-behavior/iron-fit-behavior.html"/>
+<link rel="import" href="../iron-overlay-behavior/iron-focusables-helper.html">
 
 <!--
 Modals open over the page content and prompt the user to take some actions before
@@ -264,6 +265,15 @@ Custom property | Description
         autoFitOnAttach: {
           type: Boolean,
           value: true
+        },
+
+        /**
+         * Focusable elements inside the modal, determined with
+         * `Polymer.IronFocusablesHelper.getTabbableNodes()`.
+         */
+        _focusableElements: {
+          type: Array,
+          value: []
         }
       },
 
@@ -312,19 +322,17 @@ Custom property | Description
               // focus the first one, unless the `disableAutoFocus` boolean
               // is set to `true`
               this._elementFocusedBeforeOpened = document.activeElement;
-              const focusableElements = this._getFocusableElements();
-              this._firstFocusableElement = focusableElements[0];
-              this._lastFocusableElement = focusableElements[focusableElements.length-1];
-              if (this._firstFocusableElement && !this.disableAutoFocus) {
-                this._firstFocusableElement.focus();
+              this.findFocusableElements();
+              if (this._focusableElements.length) {
+                if (this._firstFocusableElement && !this.disableAutoFocus) {
+                  this._firstFocusableElement.focus();
+                }
               }
             } else {
               // Set the display back to none to make the modal invisible
               this.$.box.style['display'] = 'none';
               // Focus the last focused element in the document unless the
               // `disableAutoFocus` boolean is set to `true`
-              this._firstFocusableElement = null;
-              this._lastFocusableElement = null;
               if (this._elementFocusedBeforeOpened && !this.disableAutoFocus) {
                 this._elementFocusedBeforeOpened.focus();
               }
@@ -336,27 +344,20 @@ Custom property | Description
       },
 
       /**
-       * Searches for focusable elements passed in via slots or created in this
-       * component's shadow DOM template. Returns an array of focusable
-       * elements.
-       *
-       * @return {Array.<HTMLElement>}
+       * Find focusable elements inside the modal by using `IronFocusablesHelper`'s
+       * `getTabbableNodes()` helper method.
+       * Call this method in case you are dymanically changing the modal's content
+       * to update the array of focusable elements .
        */
-      _getFocusableElements() {
-        const focusableElementsString = 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex="0"], [contenteditable]';
-        let focusableSlottedElements = Polymer.dom(this).querySelectorAll('button') || [];
-        if (focusableSlottedElements instanceof NodeList) {
-          focusableSlottedElements = Array.prototype.slice.call(focusableSlottedElements);
+      findFocusableElements() {
+        this._focusableElements = Polymer.IronFocusablesHelper.getTabbableNodes(this);
+        if (this._focusableElements.length) {
+          this._firstFocusableElement = this._focusableElements[0];
+          this._lastFocusableElement = this._focusableElements[this._focusableElements.length-1];
+        } else {
+          this._firstFocusableElement = null;
+          this._lastFocusableElement = null;
         }
-        const shadowAcceptTrigger = Polymer.dom(this.root).querySelector('#accept-trigger-button');
-        const shadowRejectTrigger = Polymer.dom(this.root).querySelector('#reject-trigger-button');
-        const slottedAcceptTrigger = focusableSlottedElements.find(n => n.getAttribute('slot') === 'accept-trigger');
-        const slottedRejectTrigger = focusableSlottedElements.find(n => n.getAttribute('slot') === 'reject-trigger');
-        return focusableSlottedElements
-          .filter(n => n !== slottedAcceptTrigger && n !== slottedRejectTrigger)
-          .concat([(slottedRejectTrigger || shadowRejectTrigger), (slottedAcceptTrigger || shadowAcceptTrigger)])
-          // Some items might be invisible because they are superseded by a slot, do not make those focusable
-          .filter(n => n.offsetHeight > 0);
       },
 
       /**
@@ -369,11 +370,18 @@ Custom property | Description
            * When the user tabs forward past the last focusable element,
            * focus the first focusable element
            */
-          let lastFocusedElement = Polymer.dom(evt).rootTarget;
-          if (lastFocusedElement && this._firstFocusableElement && lastFocusedElement === this._lastFocusableElement) {
-            evt.preventDefault();
-            this._firstFocusableElement.focus();
+          const lastFocusedElement = Polymer.dom(evt).rootTarget;
+          if (lastFocusedElement) {
+            const lastFocusedElementIndex = this._focusableElements.indexOf(lastFocusedElement)
+            if (this._focusableElements[lastFocusedElementIndex + 1]) {
+              this._focusableElements[lastFocusedElementIndex + 1].focus()
+            } else {
+              this._firstFocusableElement.focus();
+            }
+          } else {
+            this._firstFocusableElement.focus()
           }
+          evt.preventDefault();
         }
         if (evt.key === 'Tab' && evt.shiftKey) {
           /*
@@ -381,6 +389,18 @@ Custom property | Description
            * focus the last focusable element
            */
           let lastFocusedElement = Polymer.dom(evt).rootTarget;
+          if (lastFocusedElement) {
+            const lastFocusedElementIndex = this._focusableElements.indexOf(lastFocusedElement)
+            if (this._focusableElements[lastFocusedElementIndex - 1]) {
+              this._focusableElements[lastFocusedElementIndex - 1].focus()
+            } else {
+              this._lastFocusableElement.focus();
+            }
+          } else {
+            this._lastFocusableElement.focus()
+          }
+          evt.preventDefault();
+
           if (lastFocusedElement && this._lastFocusableElement && lastFocusedElement === this._firstFocusableElement) {
             evt.preventDefault();
             this._lastFocusableElement.focus();

--- a/test/px-modal-fixture.html
+++ b/test/px-modal-fixture.html
@@ -27,6 +27,19 @@
     <script src="px-modal-tests.js"></script>
   </head>
   <body>
+    <dom-module id="my-element">
+      <template>
+        <button>Button inside Shadow DOM</button>
+      </template>
+      <script>
+        window.addEventListener('WebComponentsReady', () => {
+          Polymer({
+            is: 'my-element'
+          })
+        });
+      </script>
+    </dom-module>
+
     <h3>Web Component Test : Fixture for px-modal</h3>
     <test-fixture id="ModalFixture">
       <template>
@@ -51,6 +64,7 @@
             <h1 slot="header">Confirm delete</h1>
             <div slot="body">
               <p>Do you want to delete this record? The record will be deleted permanently.</p>
+              <my-element></my-element>
             </div>
             <button slot="reject-trigger" id="rejectButton">Cancel</button>
             <button slot="accept-trigger" id="acceptButton">Permanently Delete Record</button>

--- a/test/px-modal-tests.js
+++ b/test/px-modal-tests.js
@@ -161,4 +161,13 @@ describe('px-modal [slots]', () => {
     slottedAcceptButton.click();
     expect(eventCallback).to.be.calledOnce;
   });
+
+  it('determines focusableElements correctly', (done) => {
+    modal.opened = true;
+    setTimeout(() => {
+      expect(modal._focusableElements.length).to.equal(3);
+      expect(modal._focusableElements[0].textContent).to.equal('Button inside Shadow DOM');
+      done();
+    }, 500) // wait for modal animation
+  })
 });


### PR DESCRIPTION
Fixes #27 

My first thought was the same as @davidrleonard's described in  https://github.com/predixdesignsystem/px-modal/issues/27#issuecomment-361775838 - a parent component (`px-modal`) should not dig into children's shadow DOMs.

Then, I realized that that's not true. That _would be_ true in the ideal world with the **native focus trap**, but since we are [performing focus trap manually](https://github.com/predixdesignsystem/px-modal/blob/master/px-modal.html#L366), there's no chance make it work so that children of a modal will handle focus (mouse, <kbd>Tab</kbd>, <kbd>Shift</kbd>+<kbd>Tab</kbd>) properly without tons of logic.

We are not living in that ideal world with focus trap provided by the platform, so we need to

![](http://s2.quickmeme.com/img/2c/2c8f0f0a93c42c5396e2d540332b14f75fb93d5d661b6ae8076b749ff5b1f36e.jpg)  

Luckily, there's [iron-focusables-helper.html](https://github.com/PolymerElements/iron-overlay-behavior/blob/master/iron-focusables-helper.html) which provide us the easy way to determine all focusable nodes both from light DOM and shadow DOM.

I added the public method `findFocusableElements()`. It's handy when the content of a modal is changing dynamically (like in the advanced filtering modal of `px-data-grid`). After changing the content, a user should call `findFocusableElements()` to update the array of focusable nodes.